### PR TITLE
Refactor evaluation CLIs into shared `src/cli_common.py`

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,12 @@
 # ZED_Rep
 
+> A practical, reproducible, and script-first implementation of **ZED (Zero-Shot Detection of AI-Generated Images)** with clean CLIs for training, scoring, and threshold tuning.
+
 Reproduction of the paper "Zero-Shot Detection of AI-Generated Images" (ZED) with lightweight PyTorch tooling for training conditional pixel models and evaluating the Δ01 detector used in the publication.
 
 ## Features
 
+- **Refactored evaluation stack** – shared `src/cli_common.py` utilities remove duplicated logic across single-image and batch evaluators, making extensions safer and easier.
 - **Hierarchical pixel heads** – scripts to train level-0 and level-1 conditional logistic heads (`x_0 \mid y_1` and `x_1 \mid y_2`) with either the residual or mixture formulation described in the paper.
 - **Turn-key evaluation utilities** – batch and single-image evaluators that build the multi-scale pyramid, run the trained heads, and report D-scores, Δ01, and |Δ01| with optional visualisations.
 - **Threshold selection helper** – compute ROC statistics and balanced-accuracy operating points from exported CSV score tables to derive production-ready decision thresholds.

--- a/eval_batch_scores.py
+++ b/eval_batch_scores.py
@@ -16,46 +16,20 @@ eval_batch_scores.py — 批量 Δ01 评测（仅对 x* 做量纲缩放）
 """
 
 from __future__ import annotations
-import argparse, csv
+
+import argparse
+import csv
 from pathlib import Path
-from typing import Dict, Iterable, List, Tuple, Optional
+from typing import Dict, List, Tuple
+
 import numpy as np
 import torch
 
+from src.cli_common import SCALE_PRESETS, apply_affine_to_x_only, iter_images
 from src.eval_core import device_auto, _nll_h_d_for_level, load_heads
-from src.utils import load_image_uint8
 from src.pyramid import build_xy_pyramid
+from src.utils import load_image_uint8
 
-SCALE_PRESETS = {
-    "uint8": (1.0, 0.0),
-    "unit":  (1.0/255.0, 0.0),
-    "tanh":  (1.0/127.5, -1.0)
-}
-IMG_EXTS = {".jpg",".jpeg",".png",".bmp",".tif",".tiff",".webp"}
-
-def _iter_images(path: str) -> Iterable[str]:
-    p = Path(path)
-    if p.is_dir():
-        for f in sorted(p.rglob("*")):
-            if f.suffix.lower() in IMG_EXTS:
-                yield str(f)
-    else:
-        if p.suffix.lower() in IMG_EXTS:
-            yield str(p)
-        else:
-            with open(p, "r", encoding="utf-8") as fh:
-                for line in fh:
-                    line = line.strip()
-                    if line:
-                        yield line
-
-def _apply_affine_to_x_only(pyr: Dict[str, torch.Tensor], a: float, b: float) -> Dict[str, torch.Tensor]:
-
-    out = dict(pyr)  # 浅拷贝
-    for k in list(pyr.keys()):
-        if k.startswith("x"):  # x0, x1, x2 ...
-            out[k] = pyr[k].to(torch.float32) * a + b
-    return out
 
 @torch.no_grad()
 def _mean_D_for_level(model, device, pyr: Dict[str, torch.Tensor], level: int, pi_temp: float) -> float:
@@ -65,18 +39,17 @@ def _mean_D_for_level(model, device, pyr: Dict[str, torch.Tensor], level: int, p
         xk, yk1 = "x1", "y2"
     else:
         xk, yk1 = "x2", "y3"
-    NLL, H, D = _nll_h_d_for_level(pyr[xk], pyr[yk1], model, device, pi_temp=pi_temp)
-    return float(D.mean().item())
+    _, _, d_map = _nll_h_d_for_level(pyr[xk], pyr[yk1], model, device, pi_temp=pi_temp)
+    return float(d_map.mean().item())
+
 
 def main():
     ap = argparse.ArgumentParser("Batch Δ01 evaluator (scale only x*, keep y* intact)")
     ap.add_argument("--dir", type=str, required=True, help="图像目录 / 单个文件 / 清单文件")
     ap.add_argument("--ckpt1", type=str, required=True, help="L1 头权重")
     ap.add_argument("--ckpt0", type=str, required=True, help="L0 头权重")
-    ap.add_argument("--scale1", type=str, default="uint8", choices=SCALE_PRESETS.keys(),
-                    help="L1 头所需的 x* 量纲")
-    ap.add_argument("--scale0", type=str, default="uint8", choices=SCALE_PRESETS.keys(),
-                    help="L0 头所需的 x* 量纲")
+    ap.add_argument("--scale1", type=str, default="uint8", choices=SCALE_PRESETS.keys(), help="L1 头所需的 x* 量纲")
+    ap.add_argument("--scale0", type=str, default="uint8", choices=SCALE_PRESETS.keys(), help="L0 头所需的 x* 量纲")
     ap.add_argument("--pi_temp1", type=float, default=1.0)
     ap.add_argument("--pi_temp0", type=float, default=1.0)
     ap.add_argument("--max_side", type=int, default=1536)
@@ -90,57 +63,50 @@ def main():
     a0, b0 = SCALE_PRESETS[args.scale0]
 
     rows: List[Tuple] = []
-    total = 0
     ok = 0
 
-    with torch.no_grad():
-        for img_path in _iter_images(args.dir):
-            total += 1
-            try:
-                x0 = load_image_uint8(img_path, require_divisible_by=8, max_long_side=args.max_side)
-                pyr_u8 = build_xy_pyramid(x0, device="cpu")  # x*: uint8, y*: float
-                # 仅缩放 x*，y* 原样
-                pyr1 = _apply_affine_to_x_only(pyr_u8, a1, b1)
-                pyr0 = _apply_affine_to_x_only(pyr_u8, a0, b0)
+    for img_path in iter_images(args.dir):
+        try:
+            x0 = load_image_uint8(img_path, require_divisible_by=8, max_long_side=args.max_side)
+            pyr_u8 = build_xy_pyramid(x0, device="cpu")
+            pyr1 = apply_affine_to_x_only(pyr_u8, a1, b1)
+            pyr0 = apply_affine_to_x_only(pyr_u8, a0, b0)
 
-                D1 = _mean_D_for_level(m1, device, pyr1, level=1, pi_temp=args.pi_temp1)
-                D0 = _mean_D_for_level(m0, device, pyr0, level=0, pi_temp=args.pi_temp0)
-                Delta01 = D0 - D1
-                AbsDelta01 = abs(Delta01)
-                AbsD0 = abs(D0)
+            d1 = _mean_D_for_level(m1, device, pyr1, level=1, pi_temp=args.pi_temp1)
+            d0 = _mean_D_for_level(m0, device, pyr0, level=0, pi_temp=args.pi_temp0)
+            delta01 = d0 - d1
+            abs_delta01 = abs(delta01)
+            abs_d0 = abs(d0)
 
-                if args.label is None:
-                    rows.append((img_path, D1, D0, Delta01, AbsDelta01, AbsD0))
-                else:
-                    rows.append((img_path, args.label, D1, D0, Delta01, AbsDelta01, AbsD0))
-                ok += 1
-            except Exception as e:
-                # 把错误也写入，便于排查
-                if args.label is None:
-                    rows.append((img_path, "ERR", "ERR", "ERR", f"{type(e).__name__}: {e}", "ERR"))
-                else:
-                    rows.append((img_path, args.label, "ERR", "ERR", "ERR", f"{type(e).__name__}: {e}", "ERR"))
+            if args.label is None:
+                rows.append((img_path, d1, d0, delta01, abs_delta01, abs_d0))
+            else:
+                rows.append((img_path, args.label, d1, d0, delta01, abs_delta01, abs_d0))
+            ok += 1
+        except Exception as e:
+            if args.label is None:
+                rows.append((img_path, "ERR", "ERR", "ERR", f"{type(e).__name__}: {e}", "ERR"))
+            else:
+                rows.append((img_path, args.label, "ERR", "ERR", "ERR", f"{type(e).__name__}: {e}", "ERR"))
 
-    out = Path(args.csv); out.parent.mkdir(parents=True, exist_ok=True)
-    with open(out, "w", newline="", encoding="utf-8") as fh:
+    out = Path(args.csv)
+    out.parent.mkdir(parents=True, exist_ok=True)
+    with out.open("w", newline="", encoding="utf-8") as fh:
+        writer = csv.writer(fh)
         if args.label is None:
-            writer = csv.writer(fh)
             writer.writerow(["path", "D1", "D0", "Delta01", "AbsDelta01", "AbsD0"])
-            writer.writerows(rows)
         else:
-            writer = csv.writer(fh)
             writer.writerow(["path", "label", "D1", "D0", "Delta01", "AbsDelta01", "AbsD0"])
-            writer.writerows(rows)
+        writer.writerows(rows)
 
-    # 仅对成功样本做个摘要
-    vals = [r[4] if args.label is None else r[5] for r in rows
-            if isinstance((r[4] if args.label is None else r[5]), (int, float))]
+    vals = [r[4] if args.label is None else r[5] for r in rows if isinstance((r[4] if args.label is None else r[5]), (int, float))]
     if vals:
         arr = np.array(vals, dtype=np.float64)
         print(f"[done] wrote {len(rows)} rows → {out}  (ok={ok}, err={len(rows)-ok})")
         print(f"[summary] |Δ01| mean={arr.mean():.4f}  median={np.median(arr):.4f}  p95={np.percentile(arr,95):.4f}")
     else:
         print(f"[done] wrote {len(rows)} rows → {out}  (no valid rows)")
+
 
 if __name__ == "__main__":
     main()

--- a/eval_delta01.py
+++ b/eval_delta01.py
@@ -13,41 +13,13 @@ eval_delta01.py — 单图 Δ01 评测（零侵入版，内置按头量纲缩放
 from __future__ import annotations
 import argparse
 from pathlib import Path
-from typing import Dict, Tuple
-import numpy as np
+from typing import Dict
 import torch
-from PIL import Image
 
-
+from src.cli_common import SCALE_PRESETS, apply_affine_all, to_uint8_gray
 from src.eval_core import device_auto, aligned_delta_map_for_visual, _nll_h_d_for_level, load_heads
 from src.utils import load_image_uint8
 from src.pyramid import build_xy_pyramid
-
-SCALE_PRESETS = {
-    "uint8": (1.0, 0.0),
-    "unit":  (1.0/255.0, 0.0),
-    "tanh":  (1.0/127.5, -1.0),
-}
-
-def _apply_affine_pyr(pyr: Dict[str, torch.Tensor], a: float, b: float) -> Dict[str, torch.Tensor]:
-    out = {}
-    for k, v in pyr.items():
-        out[k] = v.to(torch.float32) * a + b
-    return out
-
-def _to_uint8_gray(arr: torch.Tensor, robust: float = 1.0) -> Image.Image:
-    x = arr.detach().cpu().float().numpy()
-    if not np.isfinite(x).any():
-        x = np.zeros_like(x, dtype=np.float32)
-    if 0.5 < robust < 1.0:
-        lo = float(np.quantile(x, 1.0 - robust))
-        hi = float(np.quantile(x, robust))
-    else:
-        lo = float(np.nanmin(x)); hi = float(np.nanmax(x))
-    if not np.isfinite(lo): lo = 0.0
-    if not np.isfinite(hi) or hi <= lo: hi = lo + 1e-6
-    y = np.clip((x - lo) / (hi - lo), 0, 1)
-    return Image.fromarray((y * 255.0 + 0.5).astype(np.uint8), mode="L")
 
 def _calc_for_level(model, device, pyr: Dict[str, torch.Tensor], level: int, pi_temp: float):
     if level == 0: xk, yk1 = "x0", "y1"
@@ -79,8 +51,8 @@ def main():
 
     a1, b1 = SCALE_PRESETS[args.scale1]
     a0, b0 = SCALE_PRESETS[args.scale0]
-    pyr1 = _apply_affine_pyr(pyr_u8, a1, b1)
-    pyr0 = _apply_affine_pyr(pyr_u8, a0, b0)
+    pyr1 = apply_affine_all(pyr_u8, a1, b1)
+    pyr0 = apply_affine_all(pyr_u8, a0, b0)
 
     _, _, D1_map, NLL1m, H1m, D1m = _calc_for_level(m1, device, pyr1, level=1, pi_temp=args.pi_temp1)
     _, _, D0_map, NLL0m, H0m, D0m = _calc_for_level(m0, device, pyr0, level=0, pi_temp=args.pi_temp0)
@@ -92,10 +64,10 @@ def main():
 
     if args.save_maps:
         out = Path(args.out); out.mkdir(parents=True, exist_ok=True)
-        _to_uint8_gray(D1_map, robust=args.robust_vis).save(out / "D1_native.png")
-        _to_uint8_gray(D0_map, robust=args.robust_vis).save(out / "D0_native.png")
+        to_uint8_gray(D1_map, robust=args.robust_vis).save(out / "D1_native.png")
+        to_uint8_gray(D0_map, robust=args.robust_vis).save(out / "D0_native.png")
         Delta_vis = aligned_delta_map_for_visual(D0_map, D1_map, mode="area")
-        _to_uint8_gray(Delta_vis, robust=args.robust_vis).save(out / "Delta01_vis.png")
+        to_uint8_gray(Delta_vis, robust=args.robust_vis).save(out / "Delta01_vis.png")
         print(f"[ok] saved D1_native/D0_native/Delta01_vis to {out}")
 
 if __name__ == "__main__":

--- a/src/cli_common.py
+++ b/src/cli_common.py
@@ -1,0 +1,72 @@
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Dict, Iterable
+
+import numpy as np
+import torch
+from PIL import Image
+
+SCALE_PRESETS = {
+    "uint8": (1.0, 0.0),
+    "unit": (1.0 / 255.0, 0.0),
+    "tanh": (1.0 / 127.5, -1.0),
+}
+
+IMG_EXTS = {".jpg", ".jpeg", ".png", ".bmp", ".tif", ".tiff", ".webp"}
+
+
+def iter_images(path: str) -> Iterable[str]:
+    """Yield image paths from a directory, file, or newline-delimited manifest."""
+    p = Path(path)
+    if p.is_dir():
+        for f in sorted(p.rglob("*")):
+            if f.suffix.lower() in IMG_EXTS:
+                yield str(f)
+        return
+
+    if p.suffix.lower() in IMG_EXTS:
+        yield str(p)
+        return
+
+    with p.open("r", encoding="utf-8") as fh:
+        for line in fh:
+            line = line.strip()
+            if line:
+                yield line
+
+
+def apply_affine_all(pyr: Dict[str, torch.Tensor], a: float, b: float) -> Dict[str, torch.Tensor]:
+    """Apply x -> a*x+b for all tensors in pyramid dict."""
+    return {k: (v.to(torch.float32) * a + b) for k, v in pyr.items()}
+
+
+def apply_affine_to_x_only(pyr: Dict[str, torch.Tensor], a: float, b: float) -> Dict[str, torch.Tensor]:
+    """Apply x -> a*x+b only on x* entries, preserving y* entries."""
+    out = dict(pyr)
+    for k, v in pyr.items():
+        if k.startswith("x"):
+            out[k] = v.to(torch.float32) * a + b
+    return out
+
+
+def to_uint8_gray(arr: torch.Tensor, robust: float = 1.0) -> Image.Image:
+    """Normalize a 2D tensor to uint8 grayscale for quick diagnostics."""
+    x = arr.detach().cpu().float().numpy()
+    if not np.isfinite(x).any():
+        x = np.zeros_like(x, dtype=np.float32)
+
+    if 0.5 < robust < 1.0:
+        lo = float(np.quantile(x, 1.0 - robust))
+        hi = float(np.quantile(x, robust))
+    else:
+        lo = float(np.nanmin(x))
+        hi = float(np.nanmax(x))
+
+    if not np.isfinite(lo):
+        lo = 0.0
+    if not np.isfinite(hi) or hi <= lo:
+        hi = lo + 1e-6
+
+    y = np.clip((x - lo) / (hi - lo), 0, 1)
+    return Image.fromarray((y * 255.0 + 0.5).astype(np.uint8), mode="L")

--- a/src/eval_core.py
+++ b/src/eval_core.py
@@ -12,19 +12,12 @@ import torch.nn.functional as F
 
 
 from .utils import load_image_uint8
+from .cli_common import apply_affine_all
 from .pyramid import build_xy_pyramid
 from .stats import upsample_to, discretized_logistic_logpmf
 from .stats_mix import mixture_loglik_and_resp, expected_H_from_resp
 from .model_head import ResidualLogisticHead
 from .model_head_mix import MixtureLogisticHead
-
-
-def _affine_pyr(pyr, a: float, b: float):
-
-    out = {}
-    for k, v in pyr.items():
-        out[k] = (v.to(torch.float32) * a + b)
-    return out
 
 
 def device_auto() -> torch.device:
@@ -129,8 +122,8 @@ def compute_Ds_for_image(img_path, m1, m0, device,
 
     name1, a1, b1 = scale1
     name0, a0, b0 = scale0
-    pyr1 = _affine_pyr(pyr, a1, b1)
-    pyr0 = _affine_pyr(pyr, a0, b0)
+    pyr1 = apply_affine_all(pyr, a1, b1)
+    pyr0 = apply_affine_all(pyr, a0, b0)
 
     # D1 ← (x1|y2, m1) with scale1
     NLL1, H1, D1_map = _nll_h_d_for_level(pyr1["x1"], pyr1["y2"], m1, device, pi_temp=pi_temp1)
@@ -154,8 +147,8 @@ def compute_Dmaps_for_image(img_path, m1, m0, device,
     pyr = build_xy_pyramid(x0, device="cpu")
     name1, a1, b1 = scale1
     name0, a0, b0 = scale0
-    pyr1 = _affine_pyr(pyr, a1, b1)
-    pyr0 = _affine_pyr(pyr, a0, b0)
+    pyr1 = apply_affine_all(pyr, a1, b1)
+    pyr0 = apply_affine_all(pyr, a0, b0)
 
     _, _, D1_map = _nll_h_d_for_level(pyr1["x1"], pyr1["y2"], m1, device, pi_temp=pi_temp1)
     _, _, D0_map = _nll_h_d_for_level(pyr0["x0"], pyr0["y1"], m0, device, pi_temp=pi_temp0)


### PR DESCRIPTION
### Motivation
- Remove duplicated CLI and image/pyramid handling logic in the evaluation scripts to lower maintenance cost and make behavior consistent across single-image and batch evaluators. 
- Provide a small, well-scoped utility module so contributors can extend or harden the evaluation stack more easily and reliably.

### Description
- Add `src/cli_common.py` which centralizes `SCALE_PRESETS`, image-path iteration (`iter_images`), affine-scaling helpers (`apply_affine_all` and `apply_affine_to_x_only`), and a robust tensor-to-grayscale helper (`to_uint8_gray`). 
- Update `eval_delta01.py` to reuse `SCALE_PRESETS`, `apply_affine_all`, and `to_uint8_gray`, removing the script-local copies of those helpers. 
- Update `eval_batch_scores.py` to reuse `iter_images` and `apply_affine_to_x_only` and simplify the per-level D computation, removing duplicated image/scale logic. 
- Update `src/eval_core.py` to use the shared `apply_affine_all` for consistent per-head affine scaling and adjust callers accordingly, and refresh `README.md` top copy to highlight the refactor. 

### Testing
- Ran `python -m compileall src eval_delta01.py eval_batch_scores.py` which completed without errors (all modified modules compiled successfully).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ce287007e0833395cb355f54ef796c)